### PR TITLE
message: fix example formatting verb

### DIFF
--- a/message/examples_test.go
+++ b/message/examples_test.go
@@ -29,7 +29,7 @@ func Example_http() {
 func ExamplePrinter_numbers() {
 	for _, lang := range []string{"en", "de", "de-CH", "fr", "bn"} {
 		p := message.NewPrinter(language.Make(lang))
-		p.Printf("%-6s %g\n", lang, 123456.78)
+		p.Printf("%-6s %v\n", lang, 123456.78)
 	}
 
 	// Output:


### PR DESCRIPTION
Change example. %g prints, "%!g(int=10,000,000)" rather than simply, "10,000,000", for myPrinter.Sprintf or myPrinter.Printf using "%g".  Using, "%v", prints the desired output.