### PR TITLE
fix spelling error: `formates -> formats`

### DIFF
--- a/number/format.go
+++ b/number/format.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-// A FormatFunc formates a number.
+// A FormatFunc formats a number.
 type FormatFunc func(x interface{}, opts ...Option) Formatter
 
 // NewFormat creates a FormatFunc based on another FormatFunc and new options.


### PR DESCRIPTION
This PR fixes a typo in the docs for `FormatFunc`. Sorry for the tiny PR -- I would have submitted an issue if issues were enabled.