### PR TITLE
Demonstrate panic

### DIFF
--- a/language/match_test.go
+++ b/language/match_test.go
@@ -163,6 +163,7 @@ func TestRegionGroups(t *testing.T) {
 		{"es-AR", "es-MX", 4},
 		{"es-ES", "es-MX", 5},
 		{"es-PT", "es-MX", 5},
+		{"en-ZZ", "es-MX", 0},
 	}
 	for _, tc := range testCases {
 		a := MustParse(tc.a)


### PR DESCRIPTION
```
go test ./language
--- FAIL: TestRegionGroups (0.00s)
panic: runtime error: index out of range [357] with length 357 [recovered]
	panic: runtime error: index out of range [357] with length 357

goroutine 357 [running]:
testing.tRunner.func1.1(0x138cec0, 0xc000494c60)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc0004c7380)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1075 +0x41a
panic(0x138cec0, 0xc000494c60)
	/usr/local/Cellar/go/1.15.6/libexec/src/runtime/panic.go:969 +0x1b9
golang.org/x/text/language.regionGroupDist(0x139005a00cf0165, 0x141b400)
	/Users/sethvargo/Development/text/language/match.go:676 +0x13b
golang.org/x/text/language.TestRegionGroups(0xc0004c7380)
	/Users/sethvargo/Development/text/language/match_test.go:178 +0x467
testing.tRunner(0xc0004c7380, 0x13cac60)
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
	/usr/local/Cellar/go/1.15.6/libexec/src/testing/testing.go:1168 +0x2b3
FAIL	golang.org/x/text/language	0.138s
FAIL
```