### PR TITLE
language: fix TestBestMatchAlloc test

### DIFF
--- a/language/match_test.go
+++ b/language/match_test.go
@@ -242,7 +242,7 @@ func TestBestMatchAlloc(t *testing.T) {
 	m := NewMatcher(makeTagList("en sr nl"))
 	// Go allocates when creating a list of tags from a single tag!
 	list := []Tag{English}
-	avg := testtext.AllocsPerRun(1, func() {
+	avg := testtext.AllocsPerRun(100, func() {
 		m.Match(list...)
 	})
 	if avg > 0 {


### PR DESCRIPTION
The test calls testing.AllocsPerRun with a count of 1.
AllocsPerRun sets runtime.GOMAXPROCS to 1, but it doesn't prevent the runtime from descheduling a goroutine
and performing an allocation somewhere in the background.
This commit changes the test to use a number of runs large enough to average away the occasional noisy allocation.

Fixes https://github.com/golang/go/issues/45809