### PR TITLE
Fix Command Line Options for gotext

### DIFF
--- a/cmd/gotext/extract.go
+++ b/cmd/gotext/extract.go
@@ -15,7 +15,7 @@ import (
 // - message rewriting
 
 func init() {
-	lang = cmdExtract.Flag.String("lang", "en-US", "comma-separated list of languages to process")
+	cmdExtract.Flag.StringVar(&lang, "lang", lang, "comma-separated list of languages to process")
 }
 
 var cmdExtract = &Command{

--- a/cmd/gotext/generate.go
+++ b/cmd/gotext/generate.go
@@ -8,10 +8,6 @@ import (
 	"golang.org/x/text/message/pipeline"
 )
 
-func init() {
-	out = cmdGenerate.Flag.String("out", "", "output file to write to")
-}
-
 var cmdGenerate = &Command{
 	Run:       runGenerate,
 	UsageLine: "generate <package>",

--- a/cmd/gotext/main.go
+++ b/cmd/gotext/main.go
@@ -38,6 +38,8 @@ func init() {
 var (
 	srcLang = flag.String("srclang", "en-US", "the source-code language")
 	dir     = flag.String("dir", "locales", "default subdirectory to store translation files")
+	lang    = "en-US"
+	out     string
 )
 
 func config() (*pipeline.Config, error) {
@@ -46,10 +48,11 @@ func config() (*pipeline.Config, error) {
 		return nil, wrap(err, "invalid srclang")
 	}
 	return &pipeline.Config{
+		Dir:                 *dir,
 		SourceLanguage:      tag,
 		Supported:           getLangs(),
 		TranslationsPattern: `messages\.(.*)\.json`,
-		GenFile:             *out,
+		GenFile:             out,
 	}, nil
 }
 
@@ -332,7 +335,7 @@ func help(args []string) {
 }
 
 func getLangs() (tags []language.Tag) {
-	for _, t := range strings.Split(*lang, ",") {
+	for _, t := range strings.Split(lang, ",") {
 		if t == "" {
 			continue
 		}

--- a/cmd/gotext/update.go
+++ b/cmd/gotext/update.go
@@ -14,14 +14,9 @@ import (
 // - handle features (gender, plural)
 // - message rewriting
 
-var (
-	lang *string
-	out  *string
-)
-
 func init() {
-	lang = cmdUpdate.Flag.String("lang", "en-US", "comma-separated list of languages to process")
-	out = cmdUpdate.Flag.String("out", "", "output file to write to")
+	cmdUpdate.Flag.StringVar(&lang, "lang", lang, "comma-separated list of languages to process")
+	cmdUpdate.Flag.StringVar(&out, "out", out, "output file to write to")
 }
 
 var cmdUpdate = &Command{
@@ -45,7 +40,7 @@ func runUpdate(cmd *Command, config *pipeline.Config, args []string) error {
 	if err := state.Export(); err != nil {
 		return wrap(err, "export failed")
 	}
-	if *out != "" {
+	if out != "" {
 		return wrap(state.Generate(), "generation failed")
 	}
 	return nil


### PR DESCRIPTION
  * 'dir' was unused.
  * 'lang' was assigned to twice, once by the init() in extract.go and again in the init() in update.go. That caused one of them to not work.