### PR TITLE
encoding/simplifiedchinese: Fixes € encoding in GB18030

### DIFF
--- a/encoding/simplifiedchinese/all_test.go
+++ b/encoding/simplifiedchinese/all_test.go
@@ -40,7 +40,6 @@ func TestNonRepertoire(t *testing.T) {
 		{enc, HZGB2312, "a갂", "a"},
 		{enc, HZGB2312, "\u6cf5갂", "~{1C~}"},
 
-		{dec, GB18030, "\x80", "€"},
 		{dec, GB18030, "\x81", "\ufffd"},
 		{dec, GB18030, "\x81\x20", "\ufffd "},
 		{dec, GB18030, "\xfe\xfe", "\ufffd"},
@@ -125,6 +124,14 @@ func TestBasics(t *testing.T) {
 		encPrefix: "~{",
 		encoded:   ";(<dR;:x>F#,6@WCN^O`GW!#",
 		utf8:      "花间一壶酒，独酌无相亲。",
+	}, {
+		e:       GBK,
+		encoded: "\x80",
+		utf8:    "€",
+	}, {
+		e:       GB18030,
+		encoded: "\xa2\xe3",
+		utf8:    "€",
 	}}
 
 	for _, tc := range testCases {

--- a/encoding/simplifiedchinese/all_test.go
+++ b/encoding/simplifiedchinese/all_test.go
@@ -40,6 +40,9 @@ func TestNonRepertoire(t *testing.T) {
 		{enc, HZGB2312, "a갂", "a"},
 		{enc, HZGB2312, "\u6cf5갂", "~{1C~}"},
 
+		{dec, GBK, "\xa2\xe3", "€"},
+		{dec, GB18030, "\x80", "€"},
+
 		{dec, GB18030, "\x81", "\ufffd"},
 		{dec, GB18030, "\x81\x20", "\ufffd "},
 		{dec, GB18030, "\xfe\xfe", "\ufffd"},

--- a/encoding/simplifiedchinese/gbk.go
+++ b/encoding/simplifiedchinese/gbk.go
@@ -55,7 +55,7 @@ loop:
 		// Microsoft's Code Page 936 extends GBK 1.0 to encode the euro sign U+20AC
 		// as 0x80. The HTML5 specification at http://encoding.spec.whatwg.org/#gbk
 		// says to treat "gbk" as Code Page 936.
-		case c0 == 0x80:
+		case !d.gb18030 && c0 == 0x80:
 			r, size = '€', 1
 
 		case c0 < 0xff:
@@ -180,7 +180,7 @@ func (e gbkEncoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err 
 				// Microsoft's Code Page 936 extends GBK 1.0 to encode the euro sign U+20AC
 				// as 0x80. The HTML5 specification at http://encoding.spec.whatwg.org/#gbk
 				// says to treat "gbk" as Code Page 936.
-				if r == '€' {
+				if !e.gb18030 && r == '€' {
 					r = 0x80
 					goto write1
 				}

--- a/encoding/simplifiedchinese/gbk.go
+++ b/encoding/simplifiedchinese/gbk.go
@@ -55,7 +55,9 @@ loop:
 		// Microsoft's Code Page 936 extends GBK 1.0 to encode the euro sign U+20AC
 		// as 0x80. The HTML5 specification at http://encoding.spec.whatwg.org/#gbk
 		// says to treat "gbk" as Code Page 936.
-		case !d.gb18030 && c0 == 0x80:
+		// GBK’s decoder is gb18030’s decoder. https://encoding.spec.whatwg.org/#gbk-decoder
+		// If byte is 0x80, return code point U+20AC. https://encoding.spec.whatwg.org/#gb18030-decoder
+		case c0 == 0x80:
 			r, size = '€', 1
 
 		case c0 < 0xff:
@@ -180,6 +182,8 @@ func (e gbkEncoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err 
 				// Microsoft's Code Page 936 extends GBK 1.0 to encode the euro sign U+20AC
 				// as 0x80. The HTML5 specification at http://encoding.spec.whatwg.org/#gbk
 				// says to treat "gbk" as Code Page 936.
+				// GBK’s encoder is gb18030’s encoder with its _is GBK_ set to true. https://encoding.spec.whatwg.org/#gbk-encoder
+				// If _is GBK_ is true and code point is U+20AC, return byte 0x80. https://encoding.spec.whatwg.org/#gb18030-encoder
 				if !e.gb18030 && r == '€' {
 					r = 0x80
 					goto write1


### PR DESCRIPTION
The euro sign is an exception which is given a single byte code of 0x80
in Microsoft's later versions of CP936/GBK and a two byte code of A2 E3
in GB18030. https://en.wikipedia.org/wiki/GB_18030#cite_note-4

Fixes golang/go#48691