### PR TITLE
x/text: translate messages formatted via non-printf methods

### DIFF
--- a/message/examples_test.go
+++ b/message/examples_test.go
@@ -7,6 +7,7 @@ package message_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
@@ -67,4 +68,26 @@ func ExamplePrinter_mVerb() {
 	// en     You have chosen to play hockey.
 	// en-GB  You have chosen to play hockey.
 	// nl     U heeft ervoor gekozen om ijshockey te spelen.
+}
+
+// Issue 41781
+func ExamplePrinter_Print() {
+	message.SetString(language.French, "Book Now", "Réserver Maintenant")
+
+	p := message.NewPrinter(language.French)
+
+	fmt.Print(p.Sprint("Sprint: ", "Book Now", "\n"))
+	p.Fprint(os.Stdout, "Fprint: ", "Book Now", "\n")
+	p.Print("Print: ", "Book Now", "\n")
+	fmt.Print(p.Sprintln("Sprintln:", "Book Now"))
+	p.Fprintln(os.Stdout, "Fprintln:", "Book Now")
+	p.Println("Println:", "Book Now")
+
+	// Output:
+	// Sprint: Réserver Maintenant
+	// Fprint: Réserver Maintenant
+	// Print: Réserver Maintenant
+	// Sprintln: Réserver Maintenant
+	// Fprintln: Réserver Maintenant
+	// Println: Réserver Maintenant
 }

--- a/message/print.go
+++ b/message/print.go
@@ -961,12 +961,16 @@ func (p *printer) doPrintf(fmt string) {
 func (p *printer) doPrint(a []interface{}) {
 	prevString := false
 	for argNum, arg := range a {
-		isString := arg != nil && reflect.TypeOf(arg).Kind() == reflect.String
+		_, isString := arg.(string)
 		// Add a space between two non-string arguments.
 		if argNum > 0 && !isString && !prevString {
 			p.WriteByte(' ')
 		}
-		p.printArg(arg, 'v')
+		if isString {
+			p.printArg(arg, 'm')
+		} else {
+			p.printArg(arg, 'v')
+		}
 		prevString = isString
 	}
 }
@@ -978,7 +982,11 @@ func (p *printer) doPrintln(a []interface{}) {
 		if argNum > 0 {
 			p.WriteByte(' ')
 		}
-		p.printArg(arg, 'v')
+		if _, isString := arg.(string); isString {
+			p.printArg(arg, 'm')
+		} else {
+			p.printArg(arg, 'v')
+		}
 	}
 	p.WriteByte('\n')
 }


### PR DESCRIPTION
Fixes golang/go#41781