### PR TITLE
x/text: Preserve modifiers in AppendReverse() and ReverseString()

### DIFF
--- a/unicode/bidi/bidi_test.go
+++ b/unicode/bidi/bidi_test.go
@@ -321,10 +321,22 @@ func TestDoubleSetString(t *testing.T) {
 }
 
 func TestReverseString(t *testing.T) {
-	input := "(Hello)"
-	want := "(olleH)"
-	if str := ReverseString(input); str != want {
-		t.Errorf("ReverseString(%s) = %q; want %q", input, str, want)
+	testcase := []struct {
+		input string
+		want  string
+	}{
+		{"(Hello)", "(olleH)"},
+		{"nice (world) placé́́", "é́́calp (dlrow) ecin"},
+		{"äu", "uä"},
+		{"uä", "äu"},
+		{"é́́abé́́é́́", "é́́é́́baé́́"},
+		{"é́́é́́baé́́", "é́́abé́́é́́"},
+		{"✍🏾✍🏾ab✍🏾✍🏾", "✍🏾✍🏾ba✍🏾✍🏾"},
+	}
+	for _, tc := range testcase {
+		if str := ReverseString(tc.input); str != tc.want {
+			t.Errorf("ReverseString(%s) = %q; want %q", tc.input, str, tc.want)
+		}
 	}
 }
 
@@ -335,8 +347,9 @@ func TestAppendReverse(t *testing.T) {
 		want      string
 	}{
 		{"", "Hëllo", "Hëllo"},
-		{"nice (wörld)", "", "(dlröw) ecin"},
-		{"nice (wörld)", "Hëllo", "Hëllo(dlröw) ecin"},
+		{"nice (wörld) placé́́", "", "é́́calp (dlröw) ecin"},
+		{"nice (wörld) placé́́", "Hëllo", "Hëlloé́́calp (dlröw) ecin"},
+		{"✍🏾✍🏾ab✍🏾✍🏾", "✍🏾✍🏾ba✍🏾✍🏾", "✍🏾✍🏾ba✍🏾✍🏾✍🏾✍🏾ba✍🏾✍🏾"},
 	}
 	for _, tc := range testcase {
 		if r := AppendReverse([]byte(tc.outString), []byte(tc.inString)); string(r) != tc.want {


### PR DESCRIPTION
### Issue

Current implementation of **AppendReverse()** and **ReverseString()** does not check for modifier runes, which causes modifiers to be applied to wrong characters after string is reversed.

### Proposed change

**AppendReverse()** and **ReverseString()** to check for modifier runes. Unicode Character Categories M and Sk are considered as modifiers in this proposed change.

### Questions

- Is it safe to assume that categories M and Sk contain only modifiers?
- Are there any unicode modifiers not covered by categories M and Sk?

Fixes https://github.com/golang/go/issues/50633