### PR TITLE
Fix Language Translation Issue in message Package

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -65,7 +65,9 @@ func NewPrinter(t language.Tag, opts ...Option) *Printer {
 // Sprint is like fmt.Sprint, but using language-specific formatting.
 func (p *Printer) Sprint(a ...interface{}) string {
 	pp := newPrinter(p)
-	pp.doPrint(a)
+	for _, item := range a {
+		lookupAndFormat(pp, item.(Reference), nil)
+	}
 	s := pp.String()
 	pp.free()
 	return s
@@ -74,7 +76,9 @@ func (p *Printer) Sprint(a ...interface{}) string {
 // Fprint is like fmt.Fprint, but using language-specific formatting.
 func (p *Printer) Fprint(w io.Writer, a ...interface{}) (n int, err error) {
 	pp := newPrinter(p)
-	pp.doPrint(a)
+	for _, item := range a {
+		lookupAndFormat(pp, item.(Reference), nil)
+	}
 	n64, err := io.Copy(w, &pp.Buffer)
 	pp.free()
 	return int(n64), err
@@ -88,7 +92,10 @@ func (p *Printer) Print(a ...interface{}) (n int, err error) {
 // Sprintln is like fmt.Sprintln, but using language-specific formatting.
 func (p *Printer) Sprintln(a ...interface{}) string {
 	pp := newPrinter(p)
-	pp.doPrintln(a)
+	for _, item := range a {
+		lookupAndFormat(pp, item.(Reference), nil)
+		pp.doPrintln(nil)
+	}
 	s := pp.String()
 	pp.free()
 	return s
@@ -97,7 +104,10 @@ func (p *Printer) Sprintln(a ...interface{}) string {
 // Fprintln is like fmt.Fprintln, but using language-specific formatting.
 func (p *Printer) Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
 	pp := newPrinter(p)
-	pp.doPrintln(a)
+	for _, item := range a {
+		lookupAndFormat(pp, item.(Reference), nil)
+		pp.doPrintln(nil)
+	}
 	n64, err := io.Copy(w, &pp.Buffer)
 	pp.free()
 	return int(n64), err


### PR DESCRIPTION
### Problem
The current iteration of the package designed for word translation, **`golang.org/x/text/message`**, is not working as expected. The problem lies in the fact that the package's translation functions are not correctly replacing words in the output string according to the specified language. This leads to incorrect results when trying to print messages in different languages.  
  
For example, consider the following code snippet:  
```go
message.SetString(language.Japanese, "toxic", "毒性")
message.SetString(language.Russian, "toxic", "токсичный")
message.NewPrinter(language.Japanese).Println("toxic")
message.NewPrinter(language.Russian).Print("toxic")
```  
Expected results:  
```
毒性
токсичный
```
Actual results:  
```
toxic
toxic
```  
### Solution  
I have identified the issue in the **`golang.org/x/text/message`** package where the translation functions do not properly replace words based on the specified language. In my commit, I propose a fix that addresses this problem and ensures that the translation functions work as expected.

This fix involves making modifications to the formatting methods of the Printer type, such as **`Sprint`**, **`Fprint`**, **`Sprintln`** and **`Fprintln`**, so that they correctly apply the translations based on the provided language. Additionally, I have tested the changes to ensure that they produce the expected results in different languages, as demonstrated in the code snippet above.

This pull request contains the necessary code changes to resolve the issue and improve the functionality of the **`golang.org/x/text/message`** package for language translation.