### PR TITLE
message: optimize lookupAndFormat function for better performance

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -138,21 +138,20 @@ func (p *Printer) Printf(key Reference, a ...interface{}) (n int, err error) {
 
 func lookupAndFormat(p *printer, r Reference, a []interface{}) {
 	p.fmt.Reset(a)
-	var id, msg string
 	switch v := r.(type) {
 	case string:
-		id, msg = v, v
-	case key:
-		id, msg = v.id, v.fallback
-	default:
-		panic("key argument is not a Reference")
-	}
-
-	if p.catContext.Execute(id) == catalog.ErrNotFound {
-		if p.catContext.Execute(msg) == catalog.ErrNotFound {
-			p.Render(msg)
+		if p.catContext.Execute(v) == catalog.ErrNotFound {
+			p.Render(v)
 			return
 		}
+	case key:
+		if p.catContext.Execute(v.id) == catalog.ErrNotFound &&
+			p.catContext.Execute(v.fallback) == catalog.ErrNotFound {
+			p.Render(v.fallback)
+			return
+		}
+	default:
+		panic("key argument is not a Reference")
 	}
 }
 


### PR DESCRIPTION
This commit optimizes the lookupAndFormat function to reduce code redundancy
and improve performance. Benchmarks show a significant performance increase
across various Sprintf and Fprint functions.

benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: golang.org/x/text/message
                         │   old.txt   │               new.txt               │
                         │   sec/op    │   sec/op     vs base                │
SprintfPadding-12          333.0n ± 1%   216.0n ± 1%  -35.15% (p=0.000 n=10)
SprintfEmpty-12            307.3n ± 1%   170.9n ± 1%  -44.38% (p=0.000 n=10)
SprintfString-12           313.5n ± 1%   178.9n ± 2%  -42.91% (p=0.000 n=10)
SprintfTruncateString-12   315.6n ± 1%   182.3n ± 2%  -42.23% (p=0.000 n=10)
SprintfQuoteString-12      320.1n ± 0%   198.6n ± 1%  -37.96% (p=0.000 n=10)
SprintfInt-12              325.0n ± 1%   203.1n ± 1%  -37.51% (p=0.000 n=10)
SprintfIntInt-12           340.2n ± 1%   233.2n ± 2%  -31.47% (p=0.000 n=10)
SprintfPrefixedInt-12      335.2n ± 1%   226.2n ± 1%  -32.54% (p=0.000 n=10)
SprintfFloat-12            330.1n ± 1%   209.7n ± 1%  -36.48% (p=0.000 n=10)
SprintfComplex-12          365.1n ± 1%   276.0n ± 2%  -24.41% (p=0.000 n=10)
SprintfBoolean-12          311.8n ± 0%   178.6n ± 3%  -42.72% (p=0.000 n=10)
SprintfHexString-12        328.1n ± 1%   204.8n ± 2%  -37.56% (p=0.000 n=10)
SprintfHexBytes-12         334.0n ± 2%   216.4n ± 1%  -35.20% (p=0.000 n=10)
SprintfBytes-12            340.8n ± 7%   213.9n ± 1%  -37.25% (p=0.000 n=10)
SprintfStringer-12         662.5n ± 3%   453.2n ± 1%  -31.59% (p=0.000 n=10)
SprintfStructure-12        373.8n ± 6%   275.7n ± 1%  -26.23% (p=0.000 n=10)
ManyArgs-12                485.1n ± 4%   425.4n ± 1%  -12.30% (p=0.000 n=10)
FprintInt-12               265.8n ± 2%   262.0n ± 1%   -1.41% (p=0.011 n=10)
FprintfBytes-12            348.4n ± 1%   258.8n ± 1%  -25.70% (p=0.000 n=10)
FprintIntNoAlloc-12        262.0n ± 2%   261.2n ± 2%        ~ (p=0.565 n=10)
geomean                    342.4n        233.7n       -31.75%
