### PR TITLE
encoding/unicode: fix surrogate pair handling in UTF-16 decoder

### DIFF
--- a/encoding/unicode/unicode.go
+++ b/encoding/unicode/unicode.go
@@ -400,19 +400,23 @@ func (u *utf16Decoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, e
 			}
 			r, sSize = rune(x), 2
 			if utf16.IsSurrogate(r) {
-				if nSrc+3 < len(src) {
+				if isHighSurrogate(r) && nSrc+3 < len(src) {
 					x = uint16(src[nSrc+2])<<8 | uint16(src[nSrc+3])
 					if u.current.endianness == LittleEndian {
 						x = x>>8 | x<<8
 					}
-					// Save for next iteration if it is not a high surrogate.
-					if isHighSurrogate(rune(x)) {
+					// Combine into a surrogate pair only if the second
+					// code unit is a low surrogate (U+DC00..U+DFFF).
+					if isLowSurrogate(rune(x)) {
 						r, sSize = utf16.DecodeRune(r, rune(x)), 4
 					}
-				} else if !atEOF {
+				} else if isHighSurrogate(r) && !atEOF {
 					err = transform.ErrShortSrc
 					break
 				}
+				// Unpaired surrogates (low without preceding high, or
+				// high without following low) fall through and are
+				// replaced with U+FFFD by the RuneLen check below.
 			}
 			if dSize = utf8.RuneLen(r); dSize < 0 {
 				r, dSize = utf8.RuneError, 3
@@ -435,6 +439,10 @@ func (u *utf16Decoder) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, e
 }
 
 func isHighSurrogate(r rune) bool {
+	return 0xD800 <= r && r <= 0xDBFF
+}
+
+func isLowSurrogate(r rune) bool {
 	return 0xDC00 <= r && r <= 0xDFFF
 }
 


### PR DESCRIPTION
The isHighSurrogate function in the UTF-16 decoder incorrectly
checks the low surrogate range (U+DC00..U+DFFF) instead of the
high surrogate range (U+D800..U+DBFF).

    func isHighSurrogate(r rune) bool {
        return 0xDC00 <= r && r <= 0xDFFF // BUG: low range
    }

This causes two consecutive low surrogates to be incorrectly
consumed as a 4-byte surrogate pair, producing 1 replacement
character instead of 2. N consecutive low surrogates produce
N/2 replacement characters instead of N, causing data loss.

This violates:
  - Unicode Standard Chapter 3, Table 3-8 (surrogate pair
    definition: high U+D800..U+DBFF then low U+DC00..U+DFFF)
  - WHATWG Encoding Standard (each unpaired surrogate produces
    one U+FFFD)

Go's own unicode/utf16.Decode handles this correctly.

The fix:
  - Correct isHighSurrogate to check U+D800..U+DBFF
  - Add isLowSurrogate for U+DC00..U+DFFF
  - Only attempt pair decoding when first code unit is a high
    surrogate and second is a low surrogate
  - Unpaired surrogates of either type produce U+FFFD via the
    existing RuneLen check