### PR TITLE
x/text/language: count '_' alongside '-' in ParseAcceptLanguage guard

### DIFF
--- a/language/parse.go
+++ b/language/parse.go
@@ -166,7 +166,9 @@ func ParseAcceptLanguage(s string) (tag []Tag, q []float32, err error) {
 		}
 	}()
 
-	if strings.Count(s, "-") > 1000 {
+	// The BCP 47 scanner aliases '_' to '-' in scanner.init
+	// (internal/language/parse.go); the guard must count both.
+	if strings.Count(s, "-")+strings.Count(s, "_") > 1000 {
 		return nil, nil, errTagListTooLarge
 	}
 

--- a/language/parse_test.go
+++ b/language/parse_test.go
@@ -407,3 +407,18 @@ func TestParseAcceptLanguageTooBig(t *testing.T) {
 		t.Errorf("ParseAcceptLanguage() unexpected error: got %v, want %v", err, errTagListTooLarge)
 	}
 }
+
+func TestParseAcceptLanguageUnderscoreGuard(t *testing.T) {
+	// Build a payload that would trigger the quadratic path with
+	// '_' but is blocked by the dash-count guard. Verify the guard
+	// now also counts '_'.
+	parts := make([]string, 0, 1002)
+	parts = append(parts, "en")
+	for i := 0; i < 1001; i++ {
+		parts = append(parts, "abcdefghi")
+	}
+	s := strings.Join(parts, "_")
+	if _, _, err := ParseAcceptLanguage(s); err != errTagListTooLarge {
+		t.Errorf("ParseAcceptLanguage with 1001 '_' separators: got err=%v, want errTagListTooLarge", err)
+	}
+}


### PR DESCRIPTION
The BCP 47 scanner aliases '_' to '-' in scanner.init at
internal/language/parse.go lines 104-111, so a payload built
with '_' as the separator bypasses the 1000-dash guard at
language/parse.go:169 (the CVE-2022-32149 fix landed in CL
442235) and re-triggers the O(N^2) gobble path on
attacker-controlled Accept-Language input. Count both
separators in the guard.

Reproduction summary:

  100k tokens with '_' separator:  1.35 s parse time
  Same 100k tokens with '-':       49.9 us (guard fires)
  Amplification: ~27,000x

See golang/go#79684 for the full reproducer with go.mod,
main.go, and measurement output.

Test:

TestParseAcceptLanguageUnderscoreGuard in language/parse_test.go
asserts errTagListTooLarge is returned when 1001 '_' separators
are present.

Filed per the upstream invitation from the Go Security Officers:
the original security@golang.org report was determined to be not
a security issue, with an invitation to file as an upstream
change.

Fixes golang/go#79684
