### PR TITLE
language: limit TextUnmarshaler tag complexity

### DIFF
--- a/internal/language/language.go
+++ b/internal/language/language.go
@@ -164,7 +164,12 @@ func (t Tag) MarshalText() (text []byte, err error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (t *Tag) UnmarshalText(text []byte) error {
-	tag, err := Parse(string(text))
+	s := string(text)
+	if strings.Count(s, "-")+strings.Count(s, "_") > 1000 {
+		*t = Und
+		return ErrSyntax
+	}
+	tag, err := Parse(s)
 	*t = tag
 	return err
 }

--- a/internal/language/language_test.go
+++ b/internal/language/language_test.go
@@ -6,6 +6,7 @@ package language
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"golang.org/x/text/internal/testtext"
@@ -101,6 +102,19 @@ func TestMarshal(t *testing.T) {
 		}
 		if got := string(b); got != tc {
 			t.Errorf("%s: got %q; want %q", tc, got, tc)
+		}
+	}
+}
+
+func TestUnmarshalTextTooBig(t *testing.T) {
+	for _, separator := range []string{"-", "_"} {
+		text := []byte("en" + strings.Repeat(separator+"abcdefghi", 1001))
+		tag := Tag{LangID: _fr}
+		if err := tag.UnmarshalText(text); err != ErrSyntax {
+			t.Errorf("UnmarshalText with %q separators: got error %v; want %v", separator, err, ErrSyntax)
+		}
+		if got := tag.String(); got != "und" {
+			t.Errorf("UnmarshalText with %q separators: got tag %q; want und", separator, got)
 		}
 	}
 }


### PR DESCRIPTION
The BCP 47 tag parser has inherent quadratic time complexity.
ParseAcceptLanguage bounds that work, but Tag.UnmarshalText still passes
untrusted JSON, XML, and direct text input to the parser without a
complexity limit.

Reject inputs with more than 1000 total dash and underscore separators
before parsing. Count both spellings because the scanner accepts each as
a tag separator. Add regression coverage for both forms.

A 320 kB reproduction with 32,000 invalid subtags dropped from 71-77 ms
to under 1 ms. The complete x/text test suite, focused race tests, and
go vet pass.

Fixes golang/go#80160.